### PR TITLE
feat: ios release action

### DIFF
--- a/.github/workflows/ios-release.md
+++ b/.github/workflows/ios-release.md
@@ -1,0 +1,179 @@
+# iOS Reusable Release Workflow
+
+This document explains how to configure and use the reusable iOS GitHub Action for building and deploying apps to **TestFlight** or **Appetize**.  
+
+It covers:
+- Prerequisites  
+- Google Cloud setup (bucket + service account)  
+- App Store Connect API keys  
+- GitHub secrets and variables  
+- How to trigger the workflow  
+- How to verify credentials in Google Cloud Storage  
+
+## 1. Install prerequisites locally
+
+Make sure you have:
+- **Apple Developer Account access**  
+- **Google Cloud SDK** (`gcloud`) installed and authenticated  
+
+---
+
+## 2. Create a GCS bucket
+
+All App Store apps need to be signed with credentials linked to an Apple Developer account. Google Cloud Storage (GCS) will be used to store **certificates** (shared across apps in the account) and **provisioning profiles** (per‑app, stored in subfolders).
+
+If you don’t already have a bucket, create one via the console:  
+👉 https://console.cloud.google.com/storage/create-bucket  
+
+Or via CLI:
+
+```bash
+gcloud storage buckets create your-bucket-name \
+  --project your-gcp-project-id \
+  --location=us-central1 \
+  --uniform-bucket-level-access
+```
+
+**Recommendations**
+- Use a globally unique, lowercase name such as:  
+  ```
+  {org}-open-app-builder-ios-certs
+  ```
+  Example: `idems-open-app-builder-ios-certs`
+- Prefer `us-central1` for proximity to GitHub runners, unless your org requires a specific region (e.g. `europe-west1`).
+- One bucket can be shared across multiple apps. Per‑app buckets are possible but make cert renewal/revocation harder.
+
+---
+
+## 3. Create a Service Account for CI
+
+Create a service account (if not already done).  
+👉 https://console.cloud.google.com/iam-admin/serviceaccounts  
+
+Or via CLI:
+
+```bash
+gcloud iam service-accounts create open-app-builder-ci \
+  --description="Service account for Open App Builder CI" \
+  --display-name="Open App Builder CI"
+```
+
+Give it permissions:
+
+```bash
+gcloud projects add-iam-policy-binding your-gcp-project-id \
+  --member="serviceAccount:open-app-builder-ci@your-gcp-project-id.iam.gserviceaccount.com" \
+  --role="roles/storage.admin"
+```
+
+Export a JSON key:
+
+```bash
+gcloud iam service-accounts keys create open-app-builder-ci-key.json \
+  --iam-account=open-app-builder-ci@your-gcp-project-id.iam.gserviceaccount.com
+```
+
+⚠️ **Do not commit this file.**  
+After uploading to GitHub secrets, delete it locally.
+
+---
+
+## 4. Generate an App Store Connect API Key
+
+If not already created:
+
+1. Log into [App Store Connect](https://appstoreconnect.apple.com/access/integrations/api)  
+2. Go to **Integrations → App Store Connect API**  
+3. Create a new key, e.g. `[Open App Builder] CI`  
+4. Note the **Issuer ID** and **Key ID**  
+5. Download the `.p8` key file  
+
+---
+
+## 5. Configure GitHub Actions
+
+Store the following **variables** and **secrets** in your deployment repo.
+
+### Variables
+| Name | Value |
+|------|-------|
+| `GCP_IOS_CERTS_PROJECT_ID` | Google Cloud Project ID where bucket is stored |
+| `GCP_IOS_CERTS_BUCKET_ID`  | Google Cloud Bucket ID where certs are stored |
+| `APP_STORE_TEAM_ID`        | Apple Developer Team ID (from [Membership Details](https://developer.apple.com/account)) |
+
+### Secrets
+| Name | Value |
+|------|-------|
+| `GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY` | JSON contents of exported service account key |
+| `GCP_IOS_CERTS_ENCRYPTION_PASSWORD` | Custom password used by Fastlane to encrypt data in GCS |
+| `APP_STORE_CONNECT_API_KEY_ID`      | Key ID from App Store Connect |
+| `APP_STORE_CONNECT_API_ISSUER_ID`   | Issuer ID from App Store Connect |
+| `APP_STORE_CONNECT_API_KEY`         | Contents of the `.p8` key file |
+| `APPETIZE_TOKEN`                    | API token if deploying to Appetize |
+
+---
+
+## 6. Create a Workflow to Trigger the Reusable Action
+
+In your deployment repo, create a workflow file (e.g. `.github/workflows/ios-release.yml`):
+
+```yaml
+name: IOS - Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to deploy"
+        required: true
+        default: appetize
+        type: choice
+        options:
+          - appetize
+          - testflight
+
+jobs:
+  ios_build:
+    # Calls the reusable workflow from the builder repo
+    uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@main
+    with:
+      target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
+    secrets: inherit
+    # NB: secrets will need to passed explicitly if content repo is under a different org. See ../content_repository_actions/ios-release.yml for real world example
+```
+
+---
+
+## 7. Run the Reusable Workflow
+
+Trigger the workflow manually from the deployment repo.  
+Choose either `appetize` or `testflight` as the target.
+
+- `appetize` → builds an unsigned simulator `.app` and uploads to Appetize.io  
+- `testflight` → builds a signed `.ipa` and uploads to TestFlight  
+
+---
+
+## 8. Verify in GCS
+
+If deploying to **TestFlight**, Fastlane Match will populate credentials in your GCS bucket:
+
+```
+certs/
+  appstore/
+    <TEAM_ID>/
+      distribution.p12
+profiles/
+  appstore/
+    <APP_IDENTIFIER>/
+      AppStore_<APP_IDENTIFIER>.mobileprovision
+```
+
+- **Certificates** are stored under `certs/appstore/<TEAM_ID>/`  
+- **Provisioning profiles** are stored under `profiles/appstore/<APP_IDENTIFIER>/`  
+
+---
+
+✅ That’s it! You now have a reusable iOS workflow that can deploy to both **TestFlight** and **Appetize**, with credentials securely managed in Google Cloud Storage.  
+
+---

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Configure iOS
         run: |
-          echo ${{secrets.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
+          echo "$GOOGLE_SERVICES_PLIST" > ios/App/App/GoogleService-Info.plist
           yarn workflow ios configure
           npx cap sync ios
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -148,6 +148,7 @@ jobs:
   #############################################################################
 
   build_ios:
+    name: Build iOS and Release to ${{ inputs.target }}
     runs-on: macos-latest
     needs: build_web
     steps:
@@ -238,8 +239,8 @@ jobs:
           cache: yarn
       - run: yarn workspaces focus frontend --production
 
-      # Setup certs, build and upload to testflight
-      - name: Build IOS and Release
+      # Setup certs, build and upload to target (testflight or appetize)
+      - name: Build IOS and Release to ${{ inputs.target }}
         working-directory: ios/App
         # Call workflow from generated fastfile
         run: bundle exec fastlane release_${{ inputs.target }}

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,248 @@
+##################################################################################
+#         About
+##################################################################################
+# Reuseable workflow to be called from content repos.
+# Build and deploy app bundle for ios
+#
+#         Version : 1.1
+#
+##################################################################################
+#         Configuration
+##################################################################################
+env:
+  DEPLOYMENT_PRIVATE_KEY: ${{secrets.DEPLOYMENT_PRIVATE_KEY}}
+
+  GOOGLE_SERVICES_JSON: ${{secrets.GOOGLE_SERVICES_JSON}}
+  GOOGLE_SERVICES_PLIST: ${{secrets.GOOGLE_SERVICES_PLIST}}
+
+  # Required for this action
+  APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+  APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+  APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+  APP_STORE_TEAM_ID: ${{ vars.APP_STORE_TEAM_ID }}
+  GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY: ${{secrets.GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY}}
+  GCP_IOS_CERTS_BUCKET_ID: ${{ vars.GCP_IOS_CERTS_BUCKET_ID }}
+  GCP_IOS_CERTS_ENCRYPTION_PASSWORD: ${{ secrets.GCP_IOS_CERTS_ENCRYPTION_PASSWORD }}
+  GCP_IOS_CERTS_PROJECT_ID: ${{ vars.GCP_IOS_CERTS_PROJECT_ID }}
+
+  # Optional (if deploying to appetize)
+  APPETIZE_TOKEN: ${{secrets.APPETIZE_TOKEN}}
+
+  ##################################################################################
+  #         Main Code
+  ##################################################################################
+name:
+  IOS Release
+
+  # Only keep one active build per ref (e.g. pr branch, push branch, triggering workflow ref)
+concurrency:
+  group: ios-release-${{ github.workflow }}-${{ github.ref }}-${{ inputs.target }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      CONTENT_BRANCH:
+        type: string
+        description: "Specify branch for deployment"
+        default: ""
+      target:
+        type: string
+        description: testflight / appetize
+        default: testflight
+      LFS_USED:
+        default: false
+        type: boolean  
+      APP_CODE_BRANCH:
+        required: true
+        type: string
+      DEPLOYMENT_NAME:
+        required: true
+        type: string
+      PARENT_DEPLOYMENT_NAME:
+        type: string
+        default: ""
+      PARENT_DEPLOYMENT_REPO:
+        type: string
+        default: ""
+      PARENT_DEPLOYMENT_BRANCH:
+        type: string
+        default: ""
+      ENCRYPTED:
+        required: true
+        type: boolean
+    secrets:
+      DEPLOYMENT_PRIVATE_KEY:
+        description: Provide private key if deployment uses encrypted config
+      GOOGLE_SERVICES_JSON:
+        description: Google Services JSON configuration file
+      GOOGLE_SERVICES_PLIST:
+        description: Google Services PLIST configuration file
+      APP_STORE_CONNECT_API_KEY_ID:
+        description: App Store Connect API Key ID
+      APP_STORE_CONNECT_API_ISSUER_ID:
+        description: App Store Connect API Issuer ID
+      APP_STORE_CONNECT_API_KEY:
+        description: App Store Connect API Key (private key content)
+      GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY:
+        description: GCP service account key for iOS certificates bucket access
+      GCP_IOS_CERTS_ENCRYPTION_PASSWORD:
+        description: Password for encrypting/decrypting iOS certificates
+      APPETIZE_TOKEN:
+        description: Appetize API token (optional, required if target is appetize)
+
+jobs:
+  # Ensure all required secrets are populated
+  validate_env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate required secrets
+        run: |
+          set -euo pipefail
+          for var in APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_API_ISSUER_ID APP_STORE_CONNECT_API_KEY GCP_IOS_CERTS_ENCRYPTION_PASSWORD GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY; do
+            if [ -z "$(printenv "$var")" ]; then
+              echo "❌ Missing required secret: $var"
+              exit 1
+            else
+              echo "✅ $var is set"
+            fi
+          done
+      - name: Validate required variables
+        run: |
+          set -euo pipefail
+          for var in APP_STORE_TEAM_ID GCP_IOS_CERTS_BUCKET_ID GCP_IOS_CERTS_PROJECT_ID; do
+            if [ -z "${!var}" ]; then
+              echo "❌ Missing required variable: $var"
+              exit 1
+            else
+              echo "✅ $var is set"
+            fi
+          done
+      - name: Validate release target
+        run: |
+          case "${{ inputs.target }}" in
+            testflight|appetize) echo "✅ Valid target: ${{ inputs.target }}" ;;
+            *) echo "❌ Invalid target: ${{ inputs.target }}"; exit 1 ;;
+          esac
+  #############################################################################
+  #         Build Deployment Web
+  #############################################################################
+
+  build_web:
+    uses: ./.github/workflows/app-build.yml
+    needs: validate_env
+    with:
+      CONTENT_BRANCH: ${{ inputs.CONTENT_BRANCH }}
+      LFS_USED: ${{ inputs.LFS_USED }}
+      APP_CODE_BRANCH: ${{ inputs.APP_CODE_BRANCH }}
+      DEPLOYMENT_NAME: ${{ inputs.DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_NAME: ${{ inputs.PARENT_DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_REPO: ${{ inputs.PARENT_DEPLOYMENT_REPO }}
+      PARENT_DEPLOYMENT_BRANCH: ${{ inputs.PARENT_DEPLOYMENT_BRANCH }}
+      ENCRYPTED: ${{ inputs.ENCRYPTED }}
+    secrets:
+      DEPLOYMENT_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_PRIVATE_KEY }}
+
+  #############################################################################
+  #         Build IOS
+  #############################################################################
+
+  build_ios:
+    runs-on: macos-latest
+    needs: build_web
+    steps:
+      # Checkout builder repo and install node_modules so that they can be used in ios build
+      # (e.g. capacitor plugins store podfiles in node_modules)
+      - uses: actions/checkout@v4
+        with:
+          repository: "IDEMSInternational/open-app-builder.git"
+          ref: ${{inputs.APP_CODE_BRANCH}}
+
+      - name: Checkout parent repo if needed
+        if: inputs.PARENT_DEPLOYMENT_REPO != ''
+        uses: actions/checkout@v4
+        with:
+          path: ".idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
+          repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
+          ref: ${{inputs.PARENT_DEPLOYMENT_BRANCH}}
+          lfs: false
+
+      - name: Checkout deployment
+        uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.CONTENT_BRANCH}}
+          path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
+          fetch-depth: 0
+          lfs: ${{inputs.LFS_USED}}
+
+      - name: Populate Encryption key
+        if: inputs.ENCRYPTED
+        run: echo "${{secrets.DEPLOYMENT_PRIVATE_KEY}}" > ./.idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}/encrypted/private.key
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+
+      - uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: ./.yarn/cache
+          key: ${{ runner.os }}-node-modules-yarn-v1-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-yarn-v1-
+      - name: Install node modules
+        run: yarn install --immutable
+      - uses: actions/cache/save@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ./.yarn/cache
+          key: ${{ runner.os }}-node-modules-yarn-v1-${{ hashFiles('yarn.lock') }}
+
+      - name: Set deployment
+        run: yarn workflow deployment set ${{inputs.DEPLOYMENT_NAME}} --skip-refresh
+
+      - name: Download www artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: www
+
+      - name: Extract www folder
+        run: |
+          mkdir -p www
+          tar -xf artifact.tar --directory www
+
+      - name: Configure iOS
+        run: |
+          echo ${{secrets.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
+          yarn workflow ios configure
+          npx cap sync ios
+
+      # Setup ruby. Use bundler-cache to auto-install Gemfile in working directory
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+          bundler-cache: true
+          working-directory: ios/App
+
+      # Install node_module dependencies (includes capacitor plugin pods required for build)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+          cache: yarn
+      - run: yarn workspaces focus frontend --production
+
+      # Setup certs, build and upload to testflight
+      - name: Build IOS and Release
+        working-directory: ios/App
+        # Call workflow from generated fastfile
+        run: bundle exec fastlane release_${{ inputs.target }}
+
+      # Upload logs if the job fails
+      - name: Upload Xcode build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcode-build-logs
+          path: ~/Library/Logs/gym
+

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -212,9 +212,15 @@ jobs:
           mkdir -p www
           tar -xf artifact.tar --directory www
 
+      - name: Write GoogleService-Info.plist
+        run: |
+          mkdir -p ios/App/App
+          printenv GOOGLE_SERVICES_PLIST > ios/App/App/GoogleService-Info.plist
+        env:
+          GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
+
       - name: Configure iOS
         run: |
-          echo "$GOOGLE_SERVICES_PLIST" > ios/App/App/GoogleService-Info.plist
           yarn workflow ios configure
           npx cap sync ios
 

--- a/content_repository_actions/ios-release.yml
+++ b/content_repository_actions/ios-release.yml
@@ -1,0 +1,42 @@
+name: IOS - Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to deploy"
+        required: true
+        default: appetize
+        type: choice
+        options:
+          - appetize
+          - testflight
+
+jobs:
+  call_get_vars:
+    uses: ./.github/workflows/get-vars.yml  
+
+  ios_build:
+    needs: call_get_vars
+    # Calls the reusable workflow from the actions repo
+    uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@main
+    with:
+      target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
+      CONTENT_BRANCH: ""
+      APP_CODE_BRANCH: ${{ vars.APP_CODE_BRANCH }}
+      LFS_USED: ${{ needs.call_get_vars.outputs.LFS_USED == 'true' }}
+      DEPLOYMENT_NAME: ${{ needs.call_get_vars.outputs.DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_NAME: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_REPO: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_REPO }}
+      PARENT_DEPLOYMENT_BRANCH: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_BRANCH }}
+      ENCRYPTED: ${{ needs.call_get_vars.outputs.ENCRYPTED == 'true' }}
+    secrets:
+      DEPLOYMENT_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_PRIVATE_KEY }}
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+      GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY }}
+      GCP_IOS_CERTS_ENCRYPTION_PASSWORD: ${{ secrets.GCP_IOS_CERTS_ENCRYPTION_PASSWORD }}
+      APPETIZE_TOKEN: ${{ secrets.APPETIZE_TOKEN }}


### PR DESCRIPTION
ios release action, adapted from https://github.com/IDEMSInternational/open-app-builder/pull/3136

There were a few changes I needed to make to the workflow file to adapt it to the new context, namely:
- Explicitly expose the required secrets as opposed to using `inherit`
  - This is required when calling the workflow from a repo owned by a different org, as `inherit` is not supported in this case
- Explicitly expose vars as inputs
  - I believe this is required in order to use the pattern of reading vars from an env file in deployment repos via the `call_get_vars` util