### PR TITLE
chore: ios-release action targets macos-26

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -149,7 +149,7 @@ jobs:
 
   build_ios:
     name: Build iOS and Release to ${{ inputs.target }}
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: build_web
     steps:
       # Checkout builder repo and install node_modules so that they can be used in ios build

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -149,6 +149,8 @@ jobs:
 
   build_ios:
     name: Build iOS and Release to ${{ inputs.target }}
+    # As of April 2026, App Store Connect requires iOS 26.x SDK, i.e. Xcode 26.x, which is default for macos-26 runner image
+    # Will need manually updating in future to match Apple's requirements. See https://github.com/actions/runner-images
     runs-on: macos-26
     needs: build_web
     steps:


### PR DESCRIPTION
Update the `ios-release` workflow to use `macos-26` for the `build_ios` step (previously `macos-latest`).

This should address a warning from Apple received after publishing a build  of the debug app to TestFlight using the action (action run: https://github.com/IDEMSInternational/app-debug-content/actions/runs/21665033204).

> Hello,
> 
> We noticed one or more issues with a recent delivery for the following app:
> 
> - IDEMS Debug App
> - App Apple ID 6741430457
> - Version 1.9.7
> - Build 1009007
>
> Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.
> 
> ITMS-90725: SDK version issue - This app was built with the iOS 18.5 SDK. Starting April 2026, all iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution.
> 
> Apple Developer Relations

Consulting [Github's runner images docs](https://github.com/actions/runner-images):
- `macos-latest` targets `macos-15`, which in turn uses Xcode 16.x (by default) and therefore iOS 18.x SDK
- `macos-26` uses Xcode 26.x (by default) and therefore iOS 26.x SDK

Whilst github may update `macos-latest` to point to `macos-26` before the April 2026 deadline, this can't be relied upon and it makes sense to handle this ourselves.

An alternative approach would be to stick with `macos-latest` and add a step to select Xcode 26 (which is installed on `macos-15`), e.g.:
```yml
   - uses: maxim-lobanov/setup-xcode@v1
     with:
       xcode-version: '26.2'  # or '26' or latest-stable
```