### PR TITLE
feat(ios-release): run all ios workflows when configuring ios

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Configure iOS
         run: |
-          yarn workflow ios configure
+          yarn workflow ios
           npx cap sync ios
 
       # Setup ruby. Use bundler-cache to auto-install Gemfile in working directory


### PR DESCRIPTION
Updates the "Configure iOS" step of the ios-release workflow to run all ios workflow commands. 

Previously, the step only called the `configure` command (`yarn workflow ios configure`), but now all ios workflows are ran (`yarn workflow ios`). This ensures that the `generate_assets`, added in https://github.com/IDEMSInternational/open-app-builder/pull/3261, workflow also gets run.