### PR TITLE
feat: expose flag to override default readonly option

### DIFF
--- a/.github/workflows/ios-release.md
+++ b/.github/workflows/ios-release.md
@@ -134,11 +134,11 @@ on:
       allow_provisioning_changes:
         description: "Allow Fastlane to create or update provisioning profiles"
         required: true
-        default: "true"
+        default: "false"
         type: choice
         options:
-          - "true"
           - "false"
+          - "true"
 
 jobs:
   ios_build:
@@ -157,11 +157,11 @@ jobs:
 
 Trigger the workflow manually from the deployment repo.  
 Choose either `appetize` or `testflight` as the target.
-Leave `allow_provisioning_changes` set to `true` unless you need Fastlane Match to run in readonly mode.
+Leave `allow_provisioning_changes` set to `false` for repeatable readonly signing, unless you intentionally need Fastlane Match to create or update provisioning profiles.
 
 - `appetize` → builds an unsigned simulator `.app` and uploads to Appetize.io  
 - `testflight` → builds a signed `.ipa` and uploads to TestFlight  
-- `allow_provisioning_changes=false` → tells Fastlane not to create or update provisioning profiles  
+- `allow_provisioning_changes=true` → allows Fastlane to create or update provisioning profiles  
 
 ---
 

--- a/.github/workflows/ios-release.md
+++ b/.github/workflows/ios-release.md
@@ -131,6 +131,14 @@ on:
         options:
           - appetize
           - testflight
+      allow_provisioning_changes:
+        description: "Allow Fastlane to create or update provisioning profiles"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 jobs:
   ios_build:
@@ -138,6 +146,7 @@ jobs:
     uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@main
     with:
       target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
+      allow_provisioning_changes: ${{ github.event.inputs.allow_provisioning_changes == 'true' }}
     secrets: inherit
     # NB: secrets will need to passed explicitly if content repo is under a different org. See ../content_repository_actions/ios-release.yml for real world example
 ```
@@ -148,9 +157,11 @@ jobs:
 
 Trigger the workflow manually from the deployment repo.  
 Choose either `appetize` or `testflight` as the target.
+Leave `allow_provisioning_changes` set to `true` unless you need Fastlane Match to run in readonly mode.
 
 - `appetize` → builds an unsigned simulator `.app` and uploads to Appetize.io  
 - `testflight` → builds a signed `.ipa` and uploads to TestFlight  
+- `allow_provisioning_changes=false` → tells Fastlane not to create or update provisioning profiles  
 
 ---
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -72,7 +72,7 @@ on:
         required: true
         type: boolean
       allow_provisioning_changes:
-        default: true
+        default: false
         type: boolean
     secrets:
       DEPLOYMENT_PRIVATE_KEY:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -71,6 +71,9 @@ on:
       ENCRYPTED:
         required: true
         type: boolean
+      allow_provisioning_changes:
+        default: true
+        type: boolean
     secrets:
       DEPLOYMENT_PRIVATE_KEY:
         description: Provide private key if deployment uses encrypted config
@@ -246,6 +249,8 @@ jobs:
         working-directory: ios/App
         # Call workflow from generated fastfile
         run: bundle exec fastlane release_${{ inputs.target }}
+        env:
+          ALLOW_PROVISIONING_CHANGES: ${{ inputs.allow_provisioning_changes }}
 
       # Upload logs if the job fails
       - name: Upload Xcode build logs

--- a/content_repository_actions/ios-release.yml
+++ b/content_repository_actions/ios-release.yml
@@ -14,11 +14,11 @@ on:
       allow_provisioning_changes:
         description: "Allow Fastlane to create or update provisioning profiles"
         required: true
-        default: "true"
+        default: "false"
         type: choice
         options:
-          - "true"
           - "false"
+          - "true"
 
 jobs:
   call_get_vars:

--- a/content_repository_actions/ios-release.yml
+++ b/content_repository_actions/ios-release.yml
@@ -11,6 +11,14 @@ on:
         options:
           - appetize
           - testflight
+      allow_provisioning_changes:
+        description: "Allow Fastlane to create or update provisioning profiles"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 jobs:
   call_get_vars:
@@ -22,6 +30,7 @@ jobs:
     uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@main
     with:
       target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
+      allow_provisioning_changes: ${{ github.event.inputs.allow_provisioning_changes == 'true' }}
       CONTENT_BRANCH: ""
       APP_CODE_BRANCH: ${{ vars.APP_CODE_BRANCH }}
       LFS_USED: ${{ needs.call_get_vars.outputs.LFS_USED == 'true' }}


### PR DESCRIPTION
- [ ] Corresponding code repo PR (should be merged together): https://github.com/IDEMSInternational/open-app-builder/pull/3517

## Summary
Adds an `allow_provisioning_changes` option to the iOS release workflows so manually triggered deployment builds can control whether Fastlane Match is allowed to mutate provisioning state.

## Changes
- Exposes `allow_provisioning_changes` as a manual GitHub Actions dropdown, defaulting to `false`.
- Passes the selected value through the reusable iOS release workflow.
- Exports it to Fastlane as `ALLOW_PROVISIONING_CHANGES`.
- Updates the iOS release documentation and copied deployment workflow template.

## Why
When triggering the automated ios-release workflow, a provisioning profile must already exist in Fastlane files in GCS. Up until now, when we need a new provisioning profile for a deployment with a new iOS app, I have triggered the Fastlane Match workflow manually locally with `readonly: false`, exporting the relevant secrets to local variables, which automatically adds a new provisioning profile. This is an inconvenient process.

Another route is to manually create the provisioning profile via the Apple Developer portal and then upload it to the GCP bucket. However the profile name is limited by a character limit when adding via the developer portal (a limit which is seemingly bypassed when created by fastlane through the API). This is a critical issue as it could cause a mismatch between the expected profiling names. And this process is still tedious.

Therefore it would be very convenient to be able to run match with provisioning changes enabled, for first-time setup or intentional certificate/profile updates. But this is risky as the default CI behaviour – it can make builds non-deterministic, create duplicate or unexpected provisioning profiles, churn certificates, and turn CI into a stateful process that mutates Apple Developer and GCS signing state.

This option defaults deployment repos to read-only signing behaviour, maintaining previous behaviour, while allowing us to opt into automatic provisioning updates when we need them.

## Follow ups

Repos that use the `ios-release` should have their corresponding workflow file updated with the one included here. This will expose the new option, however the action should still work without these updates.