### PR TITLE
ci: raise android and ios toolchain versions in advance of Capacitor 8 upgrade

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -111,7 +111,7 @@ jobs:
           uses: actions/setup-node@v6
           with:
             node-version: 24.13.0
-        - uses: actions/cache/restore@v3
+        - uses: actions/cache/restore@v4
           id: cache
           with:
             path: ./.yarn/cache
@@ -143,16 +143,25 @@ jobs:
         #         Android Build
         #############################################################################
           # Java version mapping: https://stackoverflow.com/a/47457251/5693245
+          # AGP 8.13 requires JDK 17+; 21 matches the JDK bundled with Android Studio Otter,
+          # which is the version Capacitor 8 targets.
+          # The gradle cache key is derived by the action from the app repo's gradle files and
+          # wrapper properties, so an AGP/Gradle bump there invalidates it automatically.
         - name: Set up JDK 21
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             distribution: "temurin"
             java-version: "21"
             java-package: jdk
             cache: "gradle"
+          # Request the SDK packages explicitly rather than relying on whatever the runner image
+          # happens to preinstall. Capacitor 8 moves the app to compileSdk/targetSdk 36; installing
+          # platform 36 is a no-op for the current Capacitor 7 (SDK 35) build.
         - name: Setup Android SDK
-          uses: android-actions/setup-android@v2
-  
+          uses: android-actions/setup-android@v4
+          with:
+            packages: "platform-tools platforms;android-36 build-tools;36.0.0"
+
           # Debug APK
         - name: Build Android Debug APK
           working-directory: android

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -153,10 +153,21 @@ jobs:
   build_ios:
     name: Build iOS and Release to ${{ inputs.target }}
     # As of April 2026, App Store Connect requires iOS 26.x SDK, i.e. Xcode 26.x, which is default for macos-26 runner image
+    # Capacitor 8 also requires Xcode 26.0+ (https://capacitorjs.com/docs/updating/8-0)
     # Will need manually updating in future to match Apple's requirements. See https://github.com/actions/runner-images
     runs-on: macos-26
     needs: build_web
     steps:
+      # Select Xcode explicitly rather than relying on the runner image default, so that an
+      # image update cannot silently move the toolchain. "26" resolves to the newest 26.x
+      # installed on the image, so patch-level rotations do not break the build.
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26"
+      - name: Log Xcode version
+        run: xcodebuild -version
+
       # Checkout builder repo and install node_modules so that they can be used in ios build
       # (e.g. capacitor plugins store podfiles in node_modules)
       - uses: actions/checkout@v4
@@ -186,9 +197,9 @@ jobs:
         run: echo "${{secrets.DEPLOYMENT_PRIVATE_KEY}}" > ./.idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}/encrypted/private.key
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.17.0
+          node-version: 24.13.0
 
       - uses: actions/cache/restore@v4
         id: cache
@@ -225,22 +236,28 @@ jobs:
         env:
           GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
 
+      # `cap sync` runs `pod install`, which resolves against the Podfile.lock committed in the
+      # app repo. This is deliberate: CI builds exactly what was locked and tested locally.
+      # Do not add `pod update` here - dependency bumps belong in a PR that commits the
+      # resulting Podfile.lock, so that CI never builds something no one has verified.
       - name: Configure iOS
         run: |
           yarn workflow ios
           npx cap sync ios
 
       # Setup ruby. Use bundler-cache to auto-install Gemfile in working directory
+      # 3.4 is preinstalled on the macos-26 image, so this resolves from cache. Ruby 3.0 is EOL
+      # and is not shipped for macos-26 arm64.
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.4"
           bundler-cache: true
           working-directory: ios/App
 
       # Install node_module dependencies (includes capacitor plugin pods required for build)
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.17.0
+          node-version: 24.13.0
           cache: yarn
       - run: yarn workspaces focus frontend --production
 


### PR DESCRIPTION
## Raise CI toolchain versions for the Capacitor 8 upgrade

Prerequisite CI work for the Capacitor 7.4.5 → 8.5.x upgrade tracked in https://github.com/IDEMSInternational/open-app-builder/issues/3607. Without this, the upgrade PR fails to build.

**These workflows keep building the Capacitor 7 app until the upgrade lands.** Every version here is backwards-compatible with Capacitor 7 — Xcode 26, JDK 21 and SDK 36 all build the current app — so they are raised now rather than cut over simultaneously. Nothing in this PR depends on the upgrade having merged.

### `ios-release.yml`

| | Before | After |
|---|---|---|
| Node (both `setup-node` steps) | `20.17.0`, `setup-node@v4` | `24.13.0`, `setup-node@v6` |
| Ruby | `3.0` | `3.4` |
| Xcode | implicit (runner image default) | explicit `maxim-lobanov/setup-xcode@v1`, `xcode-version: "26"` |

Node 20 is below Capacitor 8's minimum of 22. The earlier "update actions node version to 24" pass (`bc307df`) bumped the other four workflows but missed this one; it is now consistent with them.

**Ruby 3.0 was the most likely live breakage.** The `macos-26` image ships 3.4.10 (with 3.2.11/3.3.12/4.0.6 cached) and no 3.0, which is EOL — that pin was forcing `setup-ruby` to source-build an EOL Ruby on arm64. 3.4 resolves from the image cache.

Xcode is pinned to major `26` rather than a patch: explicit about the constraint that matters (Capacitor 8 needs 26.0+) while surviving image rotation of the patch version. A `xcodebuild -version` step logs what was actually selected.

### `android-build.yml`

| | Before | After |
|---|---|---|
| `actions/setup-java` | `@v3` | `@v4` (JDK 21 unchanged) |
| `android-actions/setup-android` | `@v2`, no packages | `@v4`, `packages: "platform-tools platforms;android-36 build-tools;36.0.0"` |
| `actions/cache/restore` | `@v3` | `@v4` |

SDK 36 was already present on `ubuntu-24.04` implicitly; requesting it explicitly means an image change cannot silently remove it.

### Deliberately not changed

`pod install` is retained in the iOS lane. `Podfile.lock` is tracked in the app repo, so the right division is that the developer doing the Capacitor 8 PR runs `pod update` locally and commits the lockfile, and CI builds exactly what was locked and tested. A comment now records this so it does not get "fixed" later:

```yaml
# `cap sync` runs `pod install`, which resolves against the Podfile.lock committed in the
# app repo. This is deliberate: CI builds exactly what was locked and tested locally.
# Do not add `pod update` here - dependency bumps belong in a PR that commits the
# resulting Podfile.lock, so that CI never builds something no one has verified.
```

### Checked and already correct

- **`macos-latest` does currently ship Xcode 26** — it maps to macOS 26 Arm64, default Xcode 26.6. The runner was already pinned to `macos-26`; this PR makes the Xcode version explicit on top of that.
- **JDK 21** was already set. (AGP 8.13 requires JDK 17+, not 21 — 21 remains the right choice as it matches the JDK bundled with Android Studio Otter.)
- **Gradle needs no CI change.** The app repo commits a Gradle wrapper and both build steps invoke `./gradlew`.
- **No cache keys need hand-bumping.** The only Gradle cache is `setup-java`'s `cache: gradle`, keyed by the action on hashes of the app repo's `*.gradle*` and `gradle-wrapper.properties` — AGP 8.11→8.13 and Gradle 8.13→8.14.3 both change those, so it self-invalidates. The yarn caches are keyed on `hashFiles('yarn.lock')`.
- **Nothing pins Capacitor.** No workflow pins the CLI or a lockfile; `yarn install --immutable` installs the committed `yarn.lock` at whatever `APP_CODE_BRANCH` points to, and `npx cap` resolves the workspace-local CLI. The workflows follow the app repo automatically, in either direction.
- **CocoaPods needs no pin.** `macos-26` provides 1.17.0, ample for iOS 15 podspecs and Xcode 26; pinning the runner image already pins CocoaPods.

### Follow-ups filed separately

Pre-existing problems found while working here, deliberately not folded in:

- #34 — `GIT_SHA` reads from a non-existent `web_build` job
- #35 — `android-build.yml` restores the yarn cache but never saves it
- #36 — `actions/checkout@v3` sweep (13 usages) plus other stale action pins
- #37 — 16 KB page size compliance: verified compliant today, revisit before Feb 2027
