### PR TITLE
ci: move all actions to node24 runtimes ahead of Node 20 removal

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -77,21 +77,21 @@ jobs:
       steps:
         
         - name: Check out app code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v5
           with:
             repository: "IDEMSInternational/open-app-builder.git"
             ref: ${{inputs.APP_CODE_BRANCH}}
   
         - name: Checkout parent repo if needed
           if: inputs.PARENT_DEPLOYMENT_REPO != ''
-          uses: actions/checkout@v3
+          uses: actions/checkout@v5
           with:
             path: ".idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
             repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
             ref: ${{inputs.PARENT_DEPLOYMENT_BRANCH}}
   
         - name: Checkout deployment
-          uses: actions/checkout@v3
+          uses: actions/checkout@v5
           with:
             path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
 
@@ -111,7 +111,7 @@ jobs:
           uses: actions/setup-node@v6
           with:
             node-version: 24.13.0
-        - uses: actions/cache/restore@v4
+        - uses: actions/cache/restore@v5
           id: cache
           with:
             path: ./.yarn/cache
@@ -129,7 +129,7 @@ jobs:
           run: yarn workflow android
              
         - name: Download Build Artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@v8
           with:
             name: www
 
@@ -148,7 +148,7 @@ jobs:
           # The gradle cache key is derived by the action from the app repo's gradle files and
           # wrapper properties, so an AGP/Gradle bump there invalidates it automatically.
         - name: Set up JDK 21
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@v5
           with:
             distribution: "temurin"
             java-version: "21"
@@ -168,7 +168,7 @@ jobs:
           run: ./gradlew :app:assembleDebug
   
         - name: Upload debug apk
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: debug_apk
             path: android/app/build/outputs/apk/debug/app-debug.apk
@@ -189,7 +189,7 @@ jobs:
             keyPassword: ${{ secrets.KEY_PASSWORD }}
             
         - name: Upload release bundle
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: release_bundle
             path: ${{steps.sign_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -83,7 +83,7 @@ jobs:
 
         - name: Download Build Artifact
           id: download
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@v8
           with:
             name: release_bundle
             path: ./

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -62,14 +62,14 @@ jobs:
 
       steps:
         - name: Check out app code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
             repository: "IDEMSInternational/open-app-builder.git"
             ref: ${{inputs.APP_CODE_BRANCH}}
   
         - name: Checkout parent repo if needed
           if: inputs.PARENT_DEPLOYMENT_REPO != ''
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
             path: ".idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
             repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
@@ -78,7 +78,7 @@ jobs:
             lfs: false
   
         - name: Checkout deployment
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
             ref: ${{inputs.CONTENT_BRANCH}}
             path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
@@ -102,7 +102,7 @@ jobs:
       # As immutable install will not change cache only save new cache if not hit
       # Uses fine-grained methods from https://github.com/actions/cache
       #############################################################################
-        - uses: actions/cache/restore@v4
+        - uses: actions/cache/restore@v5
           id: cache
           with:
             path: ./.yarn/cache
@@ -111,7 +111,7 @@ jobs:
               ${{ runner.os }}-node-modules-yarn-v1-
         - name: Install node modules
           run: yarn install --immutable
-        - uses: actions/cache/save@v4
+        - uses: actions/cache/save@v5
           if: steps.cache.outputs.cache-hit != 'true'
           with:
             path: ./.yarn/cache
@@ -124,7 +124,7 @@ jobs:
           run: yarn build ${{inputs.BUILD_FLAGS}}
   
         - name: Upload artifact
-          uses: actions/upload-pages-artifact@v3
+          uses: actions/upload-pages-artifact@v5
           with:
             path: "www/"
             name: www  

--- a/.github/workflows/appetize.yml
+++ b/.github/workflows/appetize.yml
@@ -90,10 +90,10 @@ jobs:
     outputs:
       urls: ${{ steps.deploy.outputs.urls }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: debug_apk
           path: ./
@@ -110,7 +110,7 @@ jobs:
           public-key: ${{secrets.APPETIZE_APP_KEY}}
           
       - name: "Post to PR"
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           message: |
             **Android Appetize URL**

--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -66,7 +66,7 @@ jobs:
       steps:
 
       - name: Check out app code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: "IDEMSInternational/open-app-builder.git"
           ref: ${{inputs.APP_CODE_BRANCH}}
@@ -77,7 +77,7 @@ jobs:
   
       - name: Checkout parent repo if needed
         if: inputs.PARENT_DEPLOYMENT_REPO != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ".idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
           repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
@@ -86,7 +86,7 @@ jobs:
           lfs: false
 
       - name: Checkout deployment
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT }}
           path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
@@ -109,7 +109,7 @@ jobs:
       # As immutable install will not change cache only save new cache if not hit
       # Uses fine-grained methods from https://github.com/actions/cache
       #############################################################################
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache
         with:
           path: ./.yarn/cache
@@ -118,7 +118,7 @@ jobs:
             ${{ runner.os }}-node-modules-yarn-v1-
       - name: Install node modules
         run: yarn install --immutable
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ./.yarn/cache
@@ -153,7 +153,7 @@ jobs:
         #  git checkout -b automated-changes
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT }}
           # Relative path under $GITHUB_WORKSPACE to the repository. Defaults to $GITHUB_WORKSPACE.

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -74,10 +74,10 @@ jobs:
     outputs:
       urls: ${{ steps.deploy.outputs.urls }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: www
           

--- a/.github/workflows/deploy-web-preview.yml
+++ b/.github/workflows/deploy-web-preview.yml
@@ -82,10 +82,10 @@ jobs:
       urls: ${{ steps.deploy.outputs.urls }}
     steps:
       # Extract build artifact
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: www
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -170,14 +170,14 @@ jobs:
 
       # Checkout builder repo and install node_modules so that they can be used in ios build
       # (e.g. capacitor plugins store podfiles in node_modules)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: "IDEMSInternational/open-app-builder.git"
           ref: ${{inputs.APP_CODE_BRANCH}}
 
       - name: Checkout parent repo if needed
         if: inputs.PARENT_DEPLOYMENT_REPO != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ".idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
           repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
@@ -185,7 +185,7 @@ jobs:
           lfs: false
 
       - name: Checkout deployment
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{inputs.CONTENT_BRANCH}}
           path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
@@ -201,7 +201,7 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache
         with:
           path: ./.yarn/cache
@@ -210,7 +210,7 @@ jobs:
             ${{ runner.os }}-node-modules-yarn-v1-
       - name: Install node modules
         run: yarn install --immutable
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ./.yarn/cache
@@ -220,7 +220,7 @@ jobs:
         run: yarn workflow deployment set ${{inputs.DEPLOYMENT_NAME}} --skip-refresh
 
       - name: Download www artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: www
 
@@ -272,7 +272,7 @@ jobs:
       # Upload logs if the job fails
       - name: Upload Xcode build logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: xcode-build-logs
           path: ~/Library/Logs/gym

--- a/.github/workflows/translations_down.yml
+++ b/.github/workflows/translations_down.yml
@@ -64,21 +64,21 @@ jobs:
       steps:
 
       - name: Check translation repo   
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{inputs.TRANSLATION_REPO}}
           path: "translation_repo"
           ref: "main"
 
       - name: Check idems_translation
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: "IDEMSInternational/idems_translation.git"
           path: "idems_translation"
           ref: "master"
 
       - name: set up python enviroment
-        uses: actions/setup-python@v5.0.0        
+        uses: actions/setup-python@v6        
         with:
           python-version: '3.12'
 
@@ -90,7 +90,7 @@ jobs:
         run: ls -l
   
       - name: Check out app code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: "IDEMSInternational/open-app-builder.git"
           ref: ${{inputs.APP_CODE_BRANCH}}
@@ -106,7 +106,7 @@ jobs:
         
       - name: Checkout parent repo if needed
         if: inputs.PARENT_DEPLOYMENT_REPO != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: "open-app-builder/.idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
           repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
@@ -115,7 +115,7 @@ jobs:
           lfs: false
 
       - name: Checkout deployment
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT }}
           path: "open-app-builder/.idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
@@ -162,7 +162,7 @@ jobs:
       # As immutable install will not change cache only save new cache if not hit
       # Uses fine-grained methods from https://github.com/actions/cache
       #############################################################################
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache
         with:
           path: open-app-builder/.yarn/cache
@@ -174,7 +174,7 @@ jobs:
         working-directory: open-app-builder
         run: yarn install --immutable
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: open-app-builder/.yarn/cache
@@ -216,7 +216,7 @@ jobs:
         run: git remote -v
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7.0.5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT }}
           # Relative path under $GITHUB_WORKSPACE to the repository. Defaults to $GITHUB_WORKSPACE.

--- a/.github/workflows/translations_up.yml
+++ b/.github/workflows/translations_up.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
 
     - name: Check translation repo   
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.PAT }}
         repository: ${{inputs.TRANSLATION_REPO}}
@@ -56,14 +56,14 @@ jobs:
         ref: "main"
 
     - name: Check idems_translation
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: "IDEMSInternational/idems_translation.git"
         path: "idems_translation"
         ref: "master"
 
     - name: set up python enviroment
-      uses: actions/setup-python@v5.0.0        
+      uses: actions/setup-python@v6        
       with:
         python-version: '3.12'
 
@@ -75,7 +75,7 @@ jobs:
       run: ls -l
 
     - name: Check out app code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         repository: "IDEMSInternational/open-app-builder.git"
         ref: ${{inputs.APP_CODE_BRANCH}}
@@ -84,14 +84,14 @@ jobs:
 
     - name: Checkout parent repo if needed
       if: inputs.PARENT_DEPLOYMENT_REPO != ''
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         path: "open-app-builder/.idems_app/deployments/${{inputs.PARENT_DEPLOYMENT_NAME}}"
         repository: ${{inputs.PARENT_DEPLOYMENT_REPO}}
         ref: ${{inputs.PARENT_DEPLOYMENT_BRANCH}}
 
     - name: Checkout deployment
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:          
         path: "open-app-builder/.idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
 
@@ -116,7 +116,7 @@ jobs:
         #  git checkout -b automated-changes
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5.0.2
+      uses: peter-evans/create-pull-request@v8
       with:
         token: ${{ secrets.PAT }}
         # Relative path under $GITHUB_WORKSPACE to the repository. Defaults to $GITHUB_WORKSPACE.

--- a/content_repository_actions/get-vars.yml
+++ b/content_repository_actions/get-vars.yml
@@ -58,7 +58,7 @@ jobs:
       TRANSLATION_REPO: ${{ steps.export_vars.outputs.TRANSLATION_REPO }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Code branch used
         run: |


### PR DESCRIPTION
Moves every pinned action onto a Node 24 runtime. Follow-up to #38, and the mechanical half of #36.

## Why now

Node 20 is **removed from GitHub Actions runners in Fall 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions targeting node12/16/20 are currently force-run on Node 24 with a deprecation warning; once Node 20 is gone they stop working, and the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` escape hatch goes with it.

Scoped by checking `runs.using` on every pinned action rather than by version age — several actions that *look* current are still node20.

## Changes

| Action | Was | Now | Why that target |
|---|---|---|---|
| `actions/checkout` | v3 ×13, v4 ×13 | **v5** | v3=node16, v4=node20 |
| `actions/cache/{restore,save}` | v4 | **v5** | v4=node20 |
| `actions/setup-java` | v4 | **v5** | v4=node20 |
| `actions/setup-python` | v5.0.0 | **v6** | v5=node20; also drops an exact-patch pin |
| `actions/download-artifact` | v4 | **v8** | v4/v5/v6 all node20 |
| `actions/upload-artifact` | v4 | **v7** | v4/v5 node20 |
| `actions/upload-pages-artifact` | v3 | **v5** | composite; v3/v4 nest `upload-artifact@v4` (node20) |
| `peter-evans/create-pull-request` | v5.0.2, v7.0.5 | **v8** | v5=node16, v7=node20; also resolves the two-majors-apart split |
| `marocchino/sticky-pull-request-comment` | v2 | **v3** | v2=node20 |

Already node24, unchanged: `setup-node@v6`, `android-actions/setup-android@v4`, `ruby/setup-ruby@v1`, `maxim-lobanov/setup-xcode@v1`, `FirebaseExtended/action-hosting-deploy@v0`.

## Review notes

**Targets are the first node24 major, not the newest** — deliberately, to keep behavioural change minimal.

**The artifact actions are the exception and had to move as a matched set.** `upload-pages-artifact@v5` nests `upload-artifact@v7`, which does direct uploads; `download-artifact@v8` exists specifically to support that by checking `Content-Type` before unzipping. Bumping these independently to their first node24 major would risk breaking the `www` → `tar -xf artifact.tar` flow that `android-build` and `ios-release` both rely on.

**Breaking-change review.** The "Breaking Changes" sections in `setup-java@v5`, `setup-python@v6`, `cache@v5` and `download-artifact@v7` are *only* the Node 24 move plus a minimum runner version of 2.327.1. No input or output API changes, and hosted runners are well past that version. Verified `download-artifact@v8` still exposes the `download-path` output that `android-release.yml` and `appetize.yml` consume.

**One caveat worth a second opinion.** `checkout@v5.1.0` and `v6.1.0` carry a genuine breaking change — `allow-unsafe-pr-checkout`, tightening `pull_request_target` defaults ([changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-che)). Nothing in this repo uses `pull_request_target`, so it does not bite here. If a content repo calls these reusable workflows from a `pull_request_target` trigger, that should be checked.

## Testing

Not directly runnable from a branch, since content repos call these reusable workflows at `@main`. Verified statically:

- all 19 workflow files parse as YAML
- `runs.using` re-checked on every pin after the sweep; everything is node24 or composite except the three in #39
- release notes reviewed for every major jumped, for input/output API changes

## Not in scope

Three actions have no node24 version at all and need replacing rather than bumping — `r0adkll/sign-android-release@v1` (node12), `r0adkll/upload-google-play@v1.1.2` (node16), `maxep/appetize-upload-action@0.1.0` (node12). Tracked in #39, along with the `set-output` deprecation that `sign-android-release` triggers, which is the item with real urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
