### PR TITLE
fix(android-build): honour LFS_USED and CONTENT_BRANCH when checking out deployment

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -93,7 +93,14 @@ jobs:
         - name: Checkout deployment
           uses: actions/checkout@v5
           with:
+            # Match app-build.yml: without this the android job builds assets and config
+            # from the content repo's default branch while the web build uses CONTENT_BRANCH.
+            ref: ${{inputs.CONTENT_BRANCH}}
             path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
+            # Deployment assets (splash/icon) are commonly stored in lfs, and the
+            # `yarn workflow android` asset generation step reads them directly. Without
+            # this they arrive as pointer files and image processing fails.
+            lfs: ${{inputs.LFS_USED}}
 
         - name: Populate Encryption key
           if: inputs.ENCRYPTED != ''

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -93,13 +93,8 @@ jobs:
         - name: Checkout deployment
           uses: actions/checkout@v5
           with:
-            # Match app-build.yml: without this the android job builds assets and config
-            # from the content repo's default branch while the web build uses CONTENT_BRANCH.
             ref: ${{inputs.CONTENT_BRANCH}}
             path: ".idems_app/deployments/${{inputs.DEPLOYMENT_NAME}}"
-            # Deployment assets (splash/icon) are commonly stored in lfs, and the
-            # `yarn workflow android` asset generation step reads them directly. Without
-            # this they arrive as pointer files and image processing fails.
             lfs: ${{inputs.LFS_USED}}
 
         - name: Populate Encryption key


### PR DESCRIPTION
The deployment checkout in `android-build.yml` passed neither `lfs` nor `ref`, unlike the equivalent step in `app-build.yml`.

Found while migrating `app-debug-content` off the app repo's workflow copies and onto this repo ([app-debug-content#247](https://github.com/IDEMSInternational/app-debug-content/pull/247)) — the first Android release run after that migration failed.

## The LFS bug

`app-debug-content` sets `LFS_USED=true`. Without `lfs` on the checkout, the deployment's logo arrived as a Git LFS pointer file and asset generation failed:

```
Failed to generate Android assets from logo
Error: Input file contains unsupported image format
##[error]Process completed with exit code 1
```

The app repo's `reusable-android-build.yml` sets `lfs: true` on this step, with a comment explaining why:

```yaml
# TODO - assuming deployment assets used for splash/icon, so need to ensure lfs enabled
lfs: true
```

This workflow never had it, so any content repo migrating onto it silently loses LFS support. Using `${{inputs.LFS_USED}}` rather than a hardcoded `true` honours the input the workflow already declares.

## The CONTENT_BRANCH bug

The job accepts `CONTENT_BRANCH` and forwards it to `app-build`, but ignored it for its own checkout. So the Android assets and config came from the content repo's **default branch** while the web build used `CONTENT_BRANCH`.

## Compatibility

| Path | Effect |
|---|---|
| Non-LFS repos | **None.** `LFS_USED=false` → `lfs: false`, which is `actions/checkout`'s default |
| `android-release.yml` | **None.** The content-repo template does not pass `CONTENT_BRANCH`, so `ref` resolves to `""`, equivalent to omitting it |
| `appetize.yml` | **Behaviour change** — see below |

`appetize.yml` passes `CONTENT_BRANCH: ${{ github.base_ref }}`. Its Android deployment checkout therefore moves from the PR head to the PR's base branch — which is what `app-build.yml` already uses in the same run. Previously a single Appetize APK mixed web content from the base branch with assets and config from the PR head; now both come from the base branch. That is the intended reading of `CONTENT_BRANCH: github.base_ref`, and the workflow is gated behind the `Test - appetize` PR label so it runs rarely.

## Testing

Verified statically (YAML parses; input plumbing traced through both callers). The failing run this fixes is [app-debug-content run 32133128893](https://github.com/IDEMSInternational/app-debug-content/actions/runs/32133128893) — re-running Android release from that repo after merge is the real test.

Worth noting the same run confirmed the rest of the stack is healthy: the iOS run from the same commit passed `Upload artifact` → `Download www artifact` → `Extract www folder` → `Configure iOS` and reached fastlane, validating the artifact-action set from #40 and the Xcode 26 / Node 24 / Ruby 3.4 toolchain from #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
